### PR TITLE
feat(msr-test-package-b)!: make msr-test-package-a a peer dependency

### DIFF
--- a/packages/package-b/package.json
+++ b/packages/package-b/package.json
@@ -17,12 +17,14 @@
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
     "@semantic-release/github": "^7.0.7",
-    "@semantic-release/npm": "^7.0.5"
+    "@semantic-release/npm": "^7.0.5",
+    "msr-test-package-a": "^1.1.3"
   },
-  "peerDependencies": {},
+  "peerDependencies": {
+    "msr-test-package-a": "^1.1.0"
+  },
   "dependencies": {
-    "tslib": "^2.0.3",
-    "msr-test-package-a": "1.1.3"
+    "tslib": "^2.0.3"
   },
   "scripts": {
     "prepare": "npm run build",


### PR DESCRIPTION
affects: msr-test-package-b

BREAKING CHANGE:
Consumers now need to install msr-test-package-a on their own

1. Description:

2. Instructions for testing:


3. Screenshot/GIF:

4. Closes Issues: #<number> (if appropriate)

5. [x] ran commit script (`yarn c`)

*Note* If you don't run the commit script at least once, the Semantic Pull Request check will fail. Save yourself some time, and run `yarn c` and follow the prompts.

For more information see the README 